### PR TITLE
feature/针对完整 URL 计算缓存hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Runtime data
+.idea
 pids
 *.pid
 *.seed

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -153,7 +153,7 @@ class Server {
    */
   [PRIVATE.getRequestDigest](incoming) {
     this.reviseRequest(incoming);
-    const source = incoming.url;
+    const source = incoming.headers.host + incoming.url;
     const cache = this.caches.digest;
     if (! cache.has(source)) {
       // cache this slow operation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cruorin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "a light extensible cache proxy server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
incomingMessage 必须包含 headers
headers 必须有 host，且在 nodejs 中都是小写，故不需要兼容
参考：
http://nodejs.cn/api/http.html#http_agent_requests
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23